### PR TITLE
Fix code markup in the `:on_deny` option example

### DIFF
--- a/lib/hammer_plug.ex
+++ b/lib/hammer_plug.ex
@@ -100,12 +100,12 @@ defmodule Hammer.Plug do
 
   #### Examples
 
-     on_deny: &Helpers.handle_rate_limit_deny/2
-     # where `handle_rate_limit_deny/2` is something like:
-     #
-     #     def handle_rate_limit_deny(conn, _opts) do
-     #       ...
-     #     end
+      on_deny: &Helpers.handle_rate_limit_deny/2
+      # where `handle_rate_limit_deny/2` is something like:
+      #
+      #     def handle_rate_limit_deny(conn, _opts) do
+      #       ...
+      #     end
 
   """
   import Plug.Conn


### PR DESCRIPTION
Since the `:on_deny` option example uses wrong indentation (3 spaces instead of 4) it doesn't render as a code block in the docs.