### PR TITLE
Add by: {:conn, func} option

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -2,6 +2,9 @@
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
+config :hammer,
+  backend: {Hammer.Backend.ETS, expiry_ms: 3_600_000, cleanup_interval_ms: 3_600_000}
+
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this
 # file won't be loaded nor affect the parent project. For this reason,

--- a/lib/hammer_plug.ex
+++ b/lib/hammer_plug.ex
@@ -56,6 +56,9 @@ defmodule Hammer.Plug do
      function of the form `&SomeModule.some_function/1`, choose the value
      from the session, and then apply the supplied function, then use the
      return value as the identifier
+  - `{:conn, func}` -> where `func` is a function of the form
+     `&SomeModule.some_function/1` which returns a value from the conn to
+     be used as the identifier
 
   #### Examples
 
@@ -65,6 +68,9 @@ defmodule Hammer.Plug do
 
       by: {:session, :user, &Helpers.get_user_id/1} # where `get_user_id/1` is
       equivalent to `fn (u) -> u.id end`
+
+      by: {:conn, &Helpers.get_email_from_request/1} # where email_from_request/1
+      is equivalent to `fn (conn) -> conn.params["email"] end`
 
   ### :when_nil
 
@@ -188,6 +194,9 @@ defmodule Hammer.Plug do
           other ->
             func.(other)
         end
+
+      {:conn, func} ->
+        func.(conn)
     end
   end
 
@@ -207,7 +216,8 @@ defmodule Hammer.Plug do
     case by do
       :ip -> true
       {:session, key} when is_atom(key) -> true
-      {:session, key, func} when is_atom(key) and is_function(func) -> true
+      {:session, key, func} when is_atom(key) and is_function(func, 1) -> true
+      {:conn, func} when is_function(func, 1) -> true
       _ -> false
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule Hammer.Plug.MixProject do
       {:hammer, "~> 6.0"},
       {:plug, "~> 1.0"},
       {:ex_doc, "~> 0.16", only: :dev},
-      {:mock, "~> 0.2.0", only: :test}
+      {:mock, "~> 0.3.0", only: :test}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -2,9 +2,9 @@
   "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "hammer": {:hex, :hammer, "6.0.0", "72ec6fff10e9d63856968988a22ee04c4d6d5248071ddccfbda50aa6c455c1d7", [:mix], [{:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: false]}], "hexpm"},
-  "meck": {:hex, :meck, "0.8.9", "64c5c0bd8bcca3a180b44196265c8ed7594e16bcc845d0698ec6b4e577f48188", [:rebar3], [], "hexpm"},
+  "meck": {:hex, :meck, "0.8.13", "ffedb39f99b0b99703b8601c6f17c7f76313ee12de6b646e671e3188401f7866", [:rebar3], [], "hexpm"},
   "mime": {:hex, :mime, "1.3.0", "5e8d45a39e95c650900d03f897fbf99ae04f60ab1daa4a34c7a20a5151b7a5fe", [:mix], [], "hexpm"},
-  "mock": {:hex, :mock, "0.2.1", "bfdba786903e77f9c18772dee472d020ceb8ef000783e737725a4c8f54ad28ec", [:mix], [{:meck, "~> 0.8.2", [hex: :meck, repo: "hexpm", optional: false]}], "hexpm"},
+  "mock": {:hex, :mock, "0.3.3", "42a433794b1291a9cf1525c6d26b38e039e0d3a360732b5e467bfc77ef26c914", [:mix], [{:meck, "~> 0.8.13", [hex: :meck, repo: "hexpm", optional: false]}], "hexpm"},
   "plug": {:hex, :plug, "1.6.0", "90d338a44c8cd762c32d3ea324f6728445c6145b51895403854b77f1536f1617", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1 or ~> 2.4", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], [], "hexpm"},
 }


### PR DESCRIPTION
I'm interested in using this for rate limiting login attempts. However, I want to rate limit on the email that's in the request parameters, which none of the by options currently support.