### PR TITLE
Set retry-after header in default on_deny

### DIFF
--- a/lib/hammer_plug.ex
+++ b/lib/hammer_plug.ex
@@ -166,8 +166,11 @@ defmodule Hammer.Plug do
     end
   end
 
-  def default_on_deny_handler(conn, _opts) do
+  def default_on_deny_handler(conn, opts) do
+    scale_ms = Keyword.get(opts, :scale)
+
     conn
+    |> put_resp_header("retry-after", scale_ms |> div(1000) |> Integer.to_string())
     |> send_resp(429, "Too Many Requests")
     |> halt()
   end
@@ -208,7 +211,7 @@ defmodule Hammer.Plug do
         conn
 
       {:deny, _n} ->
-        on_deny_handler.(conn, [])
+        on_deny_handler.(conn, scale: scale, limit: limit)
     end
   end
 

--- a/test/hammer_plug_test.exs
+++ b/test/hammer_plug_test.exs
@@ -46,6 +46,7 @@ defmodule Hammer.PlugTest do
 
         assert conn.status == 429
         assert conn.halted == true
+        assert get_resp_header(conn, "retry-after") == ["1"]
         assert called(Hammer.check_rate("test:127.0.0.1", 1_000, 3))
       end
     end


### PR DESCRIPTION
This is very much a draft PR, I couldn't get the tests to run locally so I have no idea if it works as-is or needs some more work. Need some help from a maintainer to get this ready.

----

[From MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After):
> The Retry-After response HTTP header indicates how long the user agent should wait before making a follow-up request.
> (...)
>    When sent with a 429 (Too Many Requests) response, this indicates how long to wait before making a new request.

This seems pretty easy to do in the `on_deny` handler if we pass `scale` as an option. Since `retry-after` is usually given in seconds we do integer division on the ms value, then cast it to a string and set it as the header. Done!
In the same vein we can also make `limit` another option that custom handlers can use if they want.