### PR TITLE
Handle :error from Hammer.check_rate in do_rate_limit_check

### DIFF
--- a/lib/hammer_plug.ex
+++ b/lib/hammer_plug.ex
@@ -209,6 +209,9 @@ defmodule Hammer.Plug do
 
       {:deny, _n} ->
         on_deny_handler.(conn, [])
+
+      {:error, _reason} ->
+        on_deny_handler.(conn, [])
     end
   end
 


### PR DESCRIPTION
I'm seeing quite a few `CaseClauseError: no case clause matching: {:error, %Redix.ConnectionError{reason: :closed}}` in my app.

I'm looking into why the redis connections are being closed, but in the meantime, I thought it would be good if `do_rate_limit_check` was able to handle all the possible return values from `Hammer.check_rate` (https://github.com/ExHammer/hammer/blob/master/lib/hammer.ex#L48).

This is just the simplest solution I could think of, and might not be the best one, but it could get a discussion started at least. If an error -> denied, it might be difficult to debug a bad connection, since it would prevent the ConnectionError from showing up. Maybe `_reason` should be passed to `on_deny_handler` and it should do some logging?